### PR TITLE
Fix node selection in tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .tern-*
 /.idea
 /.vscode
+/dev/
 /dist/
 /node_modules/
 /src/parser.*

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -70,9 +70,8 @@
               graphLines.push(getGraphLine(cur.node));
             }
 
-            const posCur = tree.cursor(pos);
-
-            const nodeText = getNodeText(tree.cursor(pos));
+            const posCur = tree.cursorAt(pos);
+            const nodeText = getNodeText(posCur);
 
             const graphText = `digraph {
               ${graphLines.join('\n')}


### PR DESCRIPTION
Currently, in the tree visualizer, the only node that is always filled in grey is the top node, regardless of the position of the cursor in the query. Example with the cursor at position 12:
<img width="1440" src="https://github.com/grafana/lezer-traceql/assets/135109076/9a644e09-617b-4e7d-82bc-51486d26916d">

By looking at the code, this doesn't seem it is the desired outcome. This PR proposed a simple fix to it—it's still not perfect. Outcome with the example of before:
<img width="1440" src="https://github.com/grafana/lezer-traceql/assets/135109076/fc2d495a-1ca2-4288-ab21-e5e3f842dd59">
