### PR TITLE
Support more queries

### DIFF
--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -1,8 +1,6 @@
 
 @top TraceQL {
-    SpansetPipeline |
-    SpansetPipelineExpression |
-    ScalarPipelineExpressionFilter
+    SpansetPipelineExpression
 }
 
 @precedence {
@@ -26,6 +24,7 @@ SpansetPipelineExpression {
     SpansetPipelineExpression !Desc Desc SpansetPipelineExpression |
     SpansetPipelineExpression !Or Or SpansetPipelineExpression |
     SpansetPipelineExpression !tilde tilde SpansetPipelineExpression |
+    SpansetPipelineExpression !Pipe Pipe SpansetPipelineExpression |
     WrappedSpansetPipeline |
     SpansetPipeline
 }
@@ -40,7 +39,7 @@ SpansetPipeline {
     ScalarFilter |
     GroupOperation |
     SelectOperation |
-    SpansetPipeline !Pipe Pipe ( SpansetExpression | ScalarFilter | GroupOperation | CoalesceOperation | SelectOperation )
+    CoalesceOperation
 }
 
 GroupOperation {
@@ -76,24 +75,6 @@ SpansetFilter {
 
 ScalarFilter {
     ScalarExpression !comparisonOp ComparisonOp ScalarExpression
-}
-
-ScalarPipelineExpressionFilter {
-    ScalarPipelineExpression !comparisonOp ComparisonOp (ScalarPipelineExpression | Static)
-}
-
-ScalarPipelineExpression {
-    "(" ScalarPipelineExpression !close_paren ")" |
-    ScalarPipelineExpression !scalarOp ScalarOp ScalarPipelineExpression |
-    WrappedScalarPipeline
-}
-
-WrappedScalarPipeline {
-    "(" ScalarPipeline ")"
-}
-
-ScalarPipeline {
-    SpansetPipeline !Pipe Pipe Aggregate
 }
 
 ScalarExpression {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -326,47 +326,47 @@ TraceQL(SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(
 # { true } | max(duration) = 1h
 { true } | max(duration) = 1h
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 
 # { true } | min(duration) = 1h
 { true } | min(duration) = 1h
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 
 # { true } | sum(duration) = 1h
 { true } | sum(duration) = 1h
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 
 # { true } | max(.a) = 1
 { true } | max(.a) = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Identifier)))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Identifier)))), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | max(span.a) = 1
 { true } | max(span.a) = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Span, Identifier)))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Span, Identifier)))), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | max(resource.a) = 1
 { true } | max(resource.a) = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Resource, Identifier)))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Resource, Identifier)))), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | max(1 + .a) = 1
 { true } | max(1 + .a) = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))))), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | max((1 + .a) * 2) = 1
 { true } | max((1 + .a) * 2) = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(FieldExpression(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier)))), FieldOp, FieldExpression(Static(Integer))))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(FieldExpression(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier)))), FieldOp, FieldExpression(Static(Integer))))), ComparisonOp, ScalarExpression(Integer))))))
 
 # max(duration) > 3s | { status = error || .http.status = 500 }
 max(duration) > 3s | { status = error || .http.status = 500 }
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))), Pipe, ⚠, ⚠, ⚠, ⚠)), Or, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(⚠, FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(Integer))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static)), Or, FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(Integer)))))))))
 
 # select(.a)
 select(.a)
@@ -376,80 +376,80 @@ TraceQL(SpansetPipelineExpression(SpansetPipeline(SelectOperation(SelectArgs(Fie
 # {} | select(.a,.b,.c)
 {} | select(.a,.b,.c)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter), Pipe, SelectOperation(SelectArgs(SelectArgs(SelectArgs(FieldExpression(AttributeField(Identifier))), FieldExpression(AttributeField(Identifier))), FieldExpression(AttributeField(Identifier)))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(SelectOperation(SelectArgs(SelectArgs(SelectArgs(FieldExpression(AttributeField(Identifier))), FieldExpression(AttributeField(Identifier))), FieldExpression(AttributeField(Identifier))))))))
 
 # { true } | { .a }
 { true } | { .a }
 ==>
-TraceQL(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ⚠, ⚠, ⚠))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(AttributeField(Identifier)))))))
 
 # { true } | count() = 1
 { true } | count() = 1
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | avg(duration) = 1h
 { true } | avg(duration) = 1h
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 
 # count() = 1 | { true }
 count() = 1 | { true }
 ==>
-TraceQL(SpansetPipeline(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer)))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static))))))
 
 # { true } | count() = 1 | { true }
 { true } | count() = 1 | { true }
 ==>
-TraceQL(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static))))))
 
 # ({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })
 ({ true } | count() > 1 | { false }) && ({ true } | count() > 1 | { false })
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(WrappedSpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠))), And, SpansetPipelineExpression(WrappedSpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))))), And, SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static))))))))
 
 # ({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })
 ({ true } | count() > 1 | { false }) || ({ true } | count() > 1 | { false })
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(WrappedSpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠))), Or, SpansetPipelineExpression(WrappedSpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))), Pipe, ⚠, ⚠, ⚠)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))))), Or, SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static))))))))
 
 # { true } | coalesce()
 { true } | coalesce()
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, CoalesceOperation)))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(CoalesceOperation))))
 
 # { true } | by(1 + .a) | coalesce()
 { true } | by(1 + .a) | coalesce()
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))))), Pipe, CoalesceOperation)))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(CoalesceOperation))))
 
 # { true } | by(.a)
 { true } | by(.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(AttributeField(Identifier))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Identifier)))))))
 
 # { true } | by(1 + .a)
 { true } | by(1 + .a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier)))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))))))))
 
 # by(.a) | { true }
 by(.a) | { true }
 ==>
-TraceQL(SpansetPipeline(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Identifier)))), Pipe, ⚠, ⚠, ⚠))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Identifier))))), Pipe, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static))))))
 
 # { true } | by(name) | count() > 2
 { true } | by(name) | count() > 2
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(IntrinsicField))), Pipe, ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(IntrinsicField))))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | by(.field) | avg(.b) = 2
 { true } | by(.field) | avg(.b) = 2
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(AttributeField(Identifier)))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Identifier)))), ComparisonOp, ScalarExpression(Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Identifier)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(AttributeField(Identifier)))), ComparisonOp, ScalarExpression(Integer))))))
 
 # { true } | by(3 * .field - 2) | max(duration) < 1s
 { true } | by(3 * .field - 2) | max(duration) < 1s
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(Static))), Pipe, GroupOperation(FieldExpression(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))), FieldOp, FieldExpression(Static(Integer))))), Pipe, ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))), FieldOp, FieldExpression(Static(Integer))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 


### PR DESCRIPTION
There are some queries that are valid but are discarded by the TraceQL Lezer parser. If fact, if you look carefully in the tests, the string representations of some trees contain error nodes (`⚠`). This PR fixes the TraceQL Lezer grammar to support these queries.