### PR TITLE
Allow template variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.1",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-traceql",
-      "version": "0.0.1",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -84,6 +84,7 @@ ScalarExpression {
     Integer |
     Float |
     Duration |
+    TemplateVariable | 
     !prefix "-" Integer |
     !prefix "-" Float |
     !prefix "-" Duration
@@ -116,6 +117,7 @@ Static {
     "false" |
     "nil" |
     Duration |
+    TemplateVariable | 
     "ok" |
     "error" |
     "unset" |
@@ -150,6 +152,12 @@ AttributeField {
 
 
 @tokens {
+    identifierExpression { $[a-zA-Z_.]$[a-zA-Z0-9_.]* }
+    templateVariableWithBraces {  
+        "{" identifierExpression "}" | 
+        "{" identifierExpression ":" $[a-zA-Z0-9_.]+ "}"  
+    }
+
     whitespace { std.whitespace+ }
     String { '"' (![\\\n"]+)* '"' }
     Integer { @digit+ }
@@ -158,7 +166,9 @@ AttributeField {
 
     @precedence { Float, Duration, Integer }
 
-    Identifier { $[a-zA-Z_.]$[a-zA-Z0-9_.]* }
+    Identifier { identifierExpression | "$" templateVariableWithBraces }
+    TemplateVariable { "$" identifierExpression | "$" templateVariableWithBraces }
+
     And { "&&" }
     Or { "||" }
     Gt { ">" }


### PR DESCRIPTION
Allow template variables in TraceQL queries. This is currently need to easily allow the TraceQL editor to not consider template variables syntax errors.