### PR TITLE
Allow quotes and escaping in tag names and values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-traceql",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -160,14 +160,14 @@ AttributeField {
 }
 
 @tokens {
-    identifierExpression { $[a-zA-Z_.]$[a-zA-Z0-9_.]* }
+    identifierExpression { (('"'  (![\\"] | "\\\\" | '\\"')* '"' ) | $[a-zA-Z0-9_.])+ }
     templateVariableWithBraces {  
         "{" identifierExpression "}" | 
         "{" identifierExpression ":" $[a-zA-Z0-9_.]+ "}"  
     }
 
     whitespace { std.whitespace+ }
-    String { '"' (![\\\n"]+)* '"' }
+    String { '"' (!["\\] | '\\"' | "\\\\")* '"' }
     Integer { @digit+ }
     Float { @digit+ "." @digit+ }
     Duration { @digit+ ("ms"|"s"|"m"|"h") }


### PR DESCRIPTION
Allow tag names and values to use `"`. Examples: `{span."this name is \"special\"" = "string value with \""}`.