### PR TITLE
Add syntax for metrics queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -119,6 +119,8 @@ FieldExpression {
 }
 
 MetricsOperation {
+    MetricsOperationType "()" |
+    MetricsOperationType "(" SelectArgs ")" |
     MetricsOperationType "()" GroupOperation | 
     MetricsOperationType "(" SelectArgs ")" GroupOperation
 }

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -120,12 +120,22 @@ FieldExpression {
 
 MetricsOperation {
     MetricsOperationType "()" |
-    MetricsOperationType "(" SelectArgs ")" |
     MetricsOperationType "()" GroupOperation | 
-    MetricsOperationType "(" SelectArgs ")" GroupOperation
+    MetricsOperationType "(" MetricsArgs ")" |
+    MetricsOperationType "(" MetricsArgs ")" GroupOperation
 }
 
 MetricsOperationType { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
+
+MetricsArgs {
+    MetricsExpression |
+    MetricsArgs "," MetricsExpression
+}
+
+MetricsExpression {
+    IntrinsicField |
+    AttributeField
+}
 
 Static {
     String |

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -45,7 +45,8 @@ SpansetPipeline {
     ScalarFilter |
     GroupOperation |
     SelectOperation |
-    CoalesceOperation
+    CoalesceOperation |
+    MetricsOperation
 }
 
 GroupOperation {
@@ -64,6 +65,12 @@ SelectArgs {
     FieldExpression |
     SelectArgs "," FieldExpression
 }
+
+MetricsOperation {
+    MetricsArgs "()" GroupOperation
+}
+
+MetricsArgs { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
 
 SpansetExpression {
     "(" SpansetExpression !close_paren ")" |

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -66,12 +66,6 @@ SelectArgs {
     SelectArgs "," FieldExpression
 }
 
-MetricsOperation {
-    MetricsArgs "()" GroupOperation
-}
-
-MetricsArgs { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
-
 SpansetExpression {
     "(" SpansetExpression !close_paren ")" |
     SpansetExpression !And And SpansetExpression |
@@ -123,6 +117,13 @@ FieldExpression {
     IntrinsicField |
     AttributeField
 }
+
+MetricsOperation {
+    MetricsOperationType "()" GroupOperation | 
+    MetricsOperationType "(" SelectArgs ")" GroupOperation
+}
+
+MetricsOperationType { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
 
 Static {
     String |

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -128,11 +128,17 @@ MetricsOperation {
 MetricsOperationType { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
 
 MetricsArgs {
-    MetricsExpression |
-    MetricsArgs "," MetricsExpression
+    MetricsQuery |
+    MetricsQuery "," Duration |
+    MetricsQuery "," Float "," Duration
 }
 
-MetricsExpression {
+MetricsQuery {
+    MetricsQueryExpression |
+    MetricsQuery "," MetricsQueryExpression
+}
+
+MetricsQueryExpression {
     IntrinsicField |
     AttributeField
 }

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -128,6 +128,7 @@ MetricsOperation {
 MetricsOperationType { "rate" | "count_over_time" | "avg_over_time" | "max_over_time" | "min_over_time" | "quantile_over_time" }
 
 MetricsArgs {
+    Duration |
     MetricsQuery |
     MetricsQuery "," Duration |
     MetricsQuery "," Float "," Duration

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -461,7 +461,7 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(Span
 # { status = error } | count_over_time(5m) by (resource.a)
 { status = error } | count_over_time(5m) by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, ⚠(Duration), MetricsArgs(MetricsQuery(MetricsQueryExpression(IntrinsicField(⚠)))), GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, MetricsArgs(Duration), GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
 # { resource.service.name = "A" } | count_over_time(duration, 5m) by (resource.a)
 { resource.service.name = "A" } | count_over_time(duration, 5m) by (resource.a)

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -456,9 +456,19 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpre
 # {} | rate() by (resource.a)
 {} | rate() by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsArgs, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
-# {status=error} | count_over_time() by (resource.a)
-{status=error} | count_over_time() by (resource.a)
+# { status = error } | count_over_time() by (resource.a)
+{ status = error } | count_over_time() by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsArgs, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+
+# {resource.service.name = "A" } >> {resouce.service.name = "B" } | rate()
+{resource.service.name = "A" } >> {resouce.service.name = "B" } | rate()
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Desc, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(⚠, FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType)))))
+
+# { resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (span.http.path)
+{ resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (span.http.path)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, SelectArgs(SelectArgs(SelectArgs(FieldExpression(IntrinsicField)), FieldExpression(Static(Float))), FieldExpression(Static(Duration))), GroupOperation(FieldExpression(AttributeField(Span, Identifier))))))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -453,3 +453,12 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpre
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(FieldExpression(FieldExpression(Static(Integer)), FieldOp, FieldExpression(AttributeField(Identifier))), FieldOp, FieldExpression(Static(Integer))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(ScalarFilter(ScalarExpression(Aggregate(AggregateExpression, FieldExpression(IntrinsicField))), ComparisonOp, ScalarExpression(Duration))))))
 
+# {} | rate() by (resource.a)
+{} | rate() by (resource.a)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsArgs, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+
+# {status=error} | count_over_time() by (resource.a)
+{status=error} | count_over_time() by (resource.a)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsArgs, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -458,17 +458,22 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpre
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
-# { status = error } | count_over_time() by (resource.a)
-{ status = error } | count_over_time() by (resource.a)
+# { status = error } | count_over_time(5m) by (resource.a)
+{ status = error } | count_over_time(5m) by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, ⚠(Duration), MetricsArgs(MetricsQuery(MetricsQueryExpression(IntrinsicField(⚠)))), GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
-# {resource.service.name = "A" } >> {resouce.service.name = "B" } | rate()
-{resource.service.name = "A" } >> {resouce.service.name = "B" } | rate()
+# { resource.service.name = "A" } | count_over_time(duration, 5m) by (resource.a)
+{ resource.service.name = "A" } | count_over_time(duration, 5m) by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Desc, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(⚠, FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, MetricsArgs(MetricsQuery(MetricsQueryExpression(IntrinsicField)), Duration), GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
-# { resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (span.http.path)
-{ resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (span.http.path)
+# { resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (resource.a)
+{ resource.service.name = "A" } | quantile_over_time(duration, 0.95, 5m) by (resource.a)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, SelectArgs(SelectArgs(SelectArgs(FieldExpression(IntrinsicField)), FieldExpression(Static(Float))), FieldExpression(Static(Duration))), GroupOperation(FieldExpression(AttributeField(Span, Identifier))))))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType, MetricsArgs(MetricsQuery(MetricsQueryExpression(IntrinsicField)), Float, Duration), GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
+
+# {resource.service.name = "A" } >> {resource.service.name = "B" } | rate()
+{resource.service.name = "A" } >> {resource.service.name = "B" } | rate()
+==>
+ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Desc, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationType)))))


### PR DESCRIPTION
Adds syntax for metrics queries.

![Screenshot 2024-02-14 at 10 04 40](https://github.com/grafana/lezer-traceql/assets/90795735/b4677718-e219-4c95-9455-af7cc980a0f5)
