### PR TITLE
Show error message for invalid queries

### DIFF
--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -25,13 +25,14 @@
   </head>
   <body>
     <textarea style="width: 100%; resize: vertical" id="in" type="text">{ span.foo = 5 }</textarea>
-    <div id="cursor-pos"></div>
+    <div><span id="cursor-pos" ></span><span id="is-invalid" style="color: #ee0000"></span></div>
     <div id="out"></div>
     <script type="module">
       import('@grafana/lezer-traceql').then(
         (lezerTraceql) => {
           const inElem = document.querySelector('#in');
           const cursorPosElem = document.querySelector('#cursor-pos');
+          const isInvalidElem = document.querySelector('#is-invalid');
 
           let currentlyVisualizedText = '';
           let currentlyVisualizedPos = 0;
@@ -94,6 +95,11 @@
             currentlyVisualizedPos = pos;
 
             cursorPosElem.innerHTML = pos.toString();
+            
+            // Show error message if errors are detected.
+            // We need to enforce the inner HTML to be an empty string if there are no errors because we need
+            // to reset it in case it was set in the previous render cycle
+            isInvalidElem.innerHTML = errorNodeCursors.length ? " Invalid query!" : "";
           }
 
           render();


### PR DESCRIPTION
When queries are quite complex and thus have a huge parsing tree, it could be difficult to detect error nodes at first glance in it. As such, it can be difficult to know if a query is valid or not. 
This PR proposed to add a simple error message if a query is invalid, namely if there are error nodes in its tree:
<img width="198" alt="image" src="https://github.com/grafana/lezer-traceql/assets/135109076/413a2351-9562-4e87-ad5f-428e0ad1a3b9">
