### PR TITLE
Fix: exports must declare types for node16+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@lezer/lr": "^1.3.0"
   },
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.es.js",
     "require": "./index.cjs"
   },


### PR DESCRIPTION
Packages that declare themselves as ES modules (`"type": "module"` in package.json) that also include an `exports` property must declare a `types` property otherwise Typescript cannot find the types when typescripts `"moduleResolution": "bundler"` is set. Checking against [are the types wrong](https://arethetypeswrong.github.io/?p=%40grafana%2Flezer-traceql%400.0.17) asserts that types cannot be found for anything above node10. An example of the error can be seen below (it's the lezer-logql package but they appear to use the same package.json configs and build tooling).

![image](https://github.com/grafana/lezer-logql/assets/73201/e7d58530-92db-40c5-862f-3f9412cf2df4)
