### PR TITLE
add syntax highlighting tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.11",
+  "version": "0.0.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-traceql",
-      "version": "0.0.11",
+      "version": "0.0.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.3.0",
+        "@lezer/highlight": "^1.2.1",
         "@lezer/lr": "^1.3.0",
         "@rollup/plugin-node-resolve": "^9.0.0",
         "mocha": "10.1.0",
@@ -40,6 +41,15 @@
       "version": "1.0.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
     },
     "node_modules/@lezer/lr": {
       "version": "1.3.9",
@@ -1051,6 +1061,15 @@
           "version": "1.0.3",
           "dev": true
         }
+      }
+    },
+    "@lezer/highlight": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
+      "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/lr": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "test": "mocha test/test-*.js"
   },
   "devDependencies": {
-    "@lezer/lr": "^1.3.0",
     "@lezer/generator": "^1.3.0",
+    "@lezer/highlight": "^1.2.1",
+    "@lezer/lr": "^1.3.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "mocha": "10.1.0",
     "rollup": "^2.27.1"

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,0 +1,20 @@
+import { styleTags, tags } from '@lezer/highlight';
+
+export const traceQLHighlight = styleTags({
+  LineComment: tags.comment,
+  'Parent Resource Span Identifier': tags.labelName,
+  IntrinsicField: tags.labelName,
+  String: tags.string,
+  'Integer Float Duration': tags.number,
+  Static: tags.literal,
+  'Aggregate AggregateExpression': tags.function(tags.keyword),
+  'And Or': tags.logicOperator,
+  'Gt Lt Desc Anc tilde ExperimentalOp': tags.bitwiseOperator, // structural operators
+  ComparisonOp: tags.compareOperator,
+  Pipe: tags.operator,
+  ScalarOp: tags.arithmeticOperator,
+  '( )': tags.paren,
+  '[ ]': tags.squareBracket,
+  '{ }': tags.brace,
+  '⚠': tags.invalid,
+});

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -258,3 +258,5 @@ AttributeField {
   blockCommentNewline { "\n" }
   @else blockCommentContent
 }
+
+@external propSource traceQLHighlight from "./highlight"

--- a/tools/tree-viz.html
+++ b/tools/tree-viz.html
@@ -11,7 +11,8 @@
         "imports": {
           "@grafana/lezer-traceql": "../dist/index.es.js",
           "@lezer/lr": "https://cdn.jsdelivr.net/npm/@lezer/lr@1.3.0/dist/index.js",
-          "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.3/dist/index.js"
+          "@lezer/common": "https://cdn.jsdelivr.net/npm/@lezer/common@1.0.3/dist/index.js",
+          "@lezer/highlight": "https://cdn.jsdelivr.net/npm/@lezer/highlight@1.2.1/dist/index.js"
         }
       }
     </script>


### PR DESCRIPTION
add syntax highlighting tags using `@lezer/highlight`, similar to the Prometheus lezer package: https://github.com/prometheus/prometheus/blob/9f57f14d6c5e3c10ed212010cb34522458f43d64/web/ui/module/lezer-promql/src/highlight.js