### PR TITLE
Support new TraceQL scopes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-traceql",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -202,9 +202,15 @@ IntrinsicField {
 
 AttributeField {
     "." Identifier |
+    Event "." Identifier |
+    Instrumentation "." Identifier |
+    Link "." Identifier |
     Resource "." Identifier |
     Span "." Identifier |
     Parent "." Identifier |
+    Parent "." Event "." Identifier
+    Parent "." Instrumentation "." Identifier |
+    Parent "." Link "." Identifier |
     Parent "." Resource "." Identifier |
     Parent "." Span "." Identifier
 }
@@ -248,12 +254,15 @@ AttributeField {
     FieldOp { ComparisonOp | ScalarOp | tilde }
 
     Parent { "parent" }
+    Event { "event" }
+    Instrumentation { "instrumentation" }
+    Link { "link" }
     Resource { "resource" }
     Span { "span" }
 
     LineComment { "//" ![\n]* }
 
-    @precedence { Parent, Resource, Span, Identifier }
+    @precedence { Parent, Resource, Span, Event, Instrumentation, Link, Identifier }
 
     // Required to avoid ambiguity between "/" and "//"
     @precedence { LineComment, ScalarOp, FieldOp }


### PR DESCRIPTION
Support new scopes `link`, `event`, `instrumentation` from https://github.com/grafana/grafana/issues/89567