### PR TITLE
New features for TraceQL grammar

### DIFF
--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -1,6 +1,7 @@
 
 @top TraceQL {
-    SpansetPipelineExpression
+    SpansetPipelineExpression |
+    SpansetPipelineExpression WithHint
 }
 
 @precedence {
@@ -198,6 +199,7 @@ IntrinsicField {
     "span:kind" |
     "span:id" |
     "span:name" |
+    "span:parentID" |
     "span:status" |
     "span:statusMessage" |
     "status" |
@@ -223,6 +225,24 @@ AttributeField {
     Parent "." Link "." Identifier |
     Parent "." Resource "." Identifier |
     Parent "." Span "." Identifier
+}
+
+WithHint {
+    With "(" HintParameters ")"
+}
+
+HintParameters {
+    HintParameter
+}
+
+HintParameter {
+    HintIdentifier "=" HintValue
+}
+
+HintValue {
+    "true" |
+    "false" |
+    Integer
 }
 
 @tokens {
@@ -270,10 +290,13 @@ AttributeField {
     Link { "link" }
     Resource { "resource" }
     Span { "span" }
+    With { "with" }
+
+    HintIdentifier { "most_recent" }
 
     LineComment { "//" ![\n]* }
 
-    @precedence { Parent, Resource, Span, Event, Instrumentation, Link, Identifier }
+    @precedence { Parent, Resource, Span, Event, Instrumentation, Link, With, Identifier }
 
     // Required to avoid ambiguity between "/" and "//"
     @precedence { LineComment, ScalarOp, FieldOp }

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -241,8 +241,7 @@ HintParameter {
 
 HintValue {
     "true" |
-    "false" |
-    Integer
+    "false"
 }
 
 @tokens {

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -542,3 +542,43 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(Span
 {} | sum_over_time(resource.a) by (span.http.path)
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOverTime(MetricsOverTimeType, MetricsExpression(AttributeField(Resource, Identifier)), GroupOperation(FieldExpression(AttributeField(Span, Identifier)))))))))
+
+# Basic with hint: { true } with (most_recent=true)
+{ true } with (most_recent=true)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(Static)))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
+
+# With hint using false: { .service.name = "test" } with (most_recent=false)
+{ .service.name = "test" } with (most_recent=false)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
+
+# With hint using integer (most_recent doesn't take integer, but other hint variables do): { .service.name = "test" } with (most_recent=1)
+{ .service.name = "test" } with (most_recent=1)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue(Integer)))))
+
+# Complex query with hint: { .service.name = "test" && .http.status_code = 200 } with (most_recent=true)
+{ .service.name = "test" && .http.status_code = 200 } with (most_recent=true)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String))), And, FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(Integer))))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
+
+# Grouped query with hint: ({ .service.name = "test" }) with (most_recent=true)
+({ .service.name = "test" }) with (most_recent=true)
+==>
+TraceQL(SpansetPipelineExpression(WrappedSpansetPipeline(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String))))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
+
+# Pipeline with hint: { .service.name = "test" } | by(.service.name) with (most_recent=true)
+{ .service.name = "test" } | by(.service.name) with (most_recent=true)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Identifier)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
+
+# Without hint should still work: { .service.name = "test" }
+{ .service.name = "test" }
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))))
+
+# Intrinsic field with hint: { span:parentID = "abc123" } with (most_recent=true)
+{ span:parentID = "abc123" } with (most_recent=true)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static(String)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -553,11 +553,6 @@ TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue))))
 
-# With hint using integer (most_recent doesn't take integer, but other hint variables do): { .service.name = "test" } with (most_recent=1)
-{ .service.name = "test" } with (most_recent=1)
-==>
-TraceQL(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Identifier)), FieldOp, FieldExpression(Static(String)))))), WithHint(With, HintParameters(HintParameter(HintIdentifier, HintValue(Integer)))))
-
 # Complex query with hint: { .service.name = "test" && .http.status_code = 200 } with (most_recent=true)
 { .service.name = "test" && .http.status_code = 200 } with (most_recent=true)
 ==>


### PR DESCRIPTION
Support the following features in the TraceQL syntax grammar:

* New instrinsic field: `span:parentID`
* `with(most_recent=true)`

Fixes: #106978
Fixes: #104159