### PR TITLE
Add support for topk and bottomk 2nd level functions

### DIFF
--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -169,7 +169,7 @@ MetricsAggregatorFunctions {
     MetricsAggregatorFunctionType "(" Integer ")"
 }
 
-MetricsAggregatorFunctionType { TopK | BottomK }
+MetricsAggregatorFunctionType { "topk" | "bottomk" }
 
 Static {
     String |
@@ -300,8 +300,6 @@ HintValue {
     With { "with" }
 
     HintIdentifier { "most_recent" }
-    TopK { "topk" }
-    BottomK { "bottomk" }
 
     LineComment { "//" ![\n]* }
 

--- a/src/traceql.grammar
+++ b/src/traceql.grammar
@@ -49,7 +49,8 @@ SpansetPipeline {
     GroupOperation |
     SelectOperation |
     CoalesceOperation |
-    MetricsOperation
+    MetricsOperation |
+    MetricsAggregatorFunctions
 }
 
 GroupOperation {
@@ -96,7 +97,7 @@ ScalarExpression {
     Integer |
     Float |
     Duration |
-    TemplateVariable | 
+    TemplateVariable |
     !prefix "-" Integer |
     !prefix "-" Float |
     !prefix "-" Duration
@@ -164,6 +165,12 @@ MetricsExpression {
     AttributeField
 }
 
+MetricsAggregatorFunctions {
+    MetricsAggregatorFunctionType "(" Integer ")"
+}
+
+MetricsAggregatorFunctionType { TopK | BottomK }
+
 Static {
     String |
     Integer |
@@ -172,7 +179,7 @@ Static {
     "false" |
     "nil" |
     Duration |
-    TemplateVariable | 
+    TemplateVariable |
     "ok" |
     "error" |
     "unset" |
@@ -251,9 +258,9 @@ HintValue {
     // Some valid queries are currently not handled by the parser, because there are some issues in writing the correct regex.
     // We should handle this, and potentially also simplify the regex.
     identifierExpression { (('"'  (![\\"] | "\\\\" | '\\"')* '"' ) | $[a-zA-Z_@#$%*-+?:;'`]) (('"'  (![\\"] | "\\\\" | '\\"')* '"' ) | ![^{}()=~!<>&|," ])* }
-    templateVariableWithBraces {  
-        "{" identifierExpression "}" | 
-        "{" identifierExpression ":" $[a-zA-Z0-9_.]+ "}"  
+    templateVariableWithBraces {
+        "{" identifierExpression "}" |
+        "{" identifierExpression ":" $[a-zA-Z0-9_.]+ "}"
     }
 
     whitespace { std.whitespace+ }
@@ -293,10 +300,12 @@ HintValue {
     With { "with" }
 
     HintIdentifier { "most_recent" }
+    TopK { "topk" }
+    BottomK { "bottomk" }
 
     LineComment { "//" ![\n]* }
 
-    @precedence { Parent, Resource, Span, Event, Instrumentation, Link, With, Identifier }
+    @precedence { Parent, Resource, Span, Event, Instrumentation, Link, With, TopK, BottomK, Identifier }
 
     // Required to avoid ambiguity between "/" and "//"
     @precedence { LineComment, ScalarOp, FieldOp }

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -483,7 +483,7 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpre
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Span, Identifier)), FieldOp, FieldExpression(Static(String)))))), UnionStructuralOp, SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Span, Identifier)), FieldOp, FieldExpression(Static(Integer)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(GroupOperation(FieldExpression(AttributeField(Resource, Identifier))))))))
 
-# {} &>> {} 
+# {} &>> {}
 {} &>> {}
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), UnionStructuralOp, SpansetPipelineExpression(SpansetPipeline(SpansetFilter))))
@@ -498,7 +498,7 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(Span
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), UnionStructuralOp, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String))))))))
 
-# {resource.service.name="frontend"} &> {resource.service.name="backend"} 
+# {resource.service.name="frontend"} &> {resource.service.name="backend"}
 {resource.service.name="frontend"} &> {resource.service.name="backend"}
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), UnionStructuralOp, SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String))))))))
@@ -607,3 +607,33 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(Span
 { resource.service.name="test" } | compare({})
 ==>
 TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationCompare(SpansetFilter))))))
+
+# TopK basic: { } | rate() by(resource.service.name) | topk(5)
+{ } | rate() by(resource.service.name) | topk(5)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+
+# BottomK basic: { } | rate() by(resource.service.name) | bottomk(5)
+{ } | rate() by(resource.service.name) | bottomk(5)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))
+
+# TopK with more complex query: { resource.service.name = "foo" } | rate() by (span.http.url) | topk(10)
+{ resource.service.name = "foo" } | rate() by (span.http.url) | topk(10)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Span, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+
+# BottomK with histogram: { status = error } | histogram_over_time(duration) by(resource.a) | bottomk(3)
+{ status = error } | histogram_over_time(duration) by(resource.a) | bottomk(3)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationHistogram(MetricsExpression(IntrinsicField), GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))
+
+# TopK without grouping: { } | rate() | topk(5)
+{ } | rate() | topk(5)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+
+# BottomK without grouping: { } | rate() | bottomk(5)
+{ } | rate() | bottomk(5)
+==>
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))

--- a/test/expression.txt
+++ b/test/expression.txt
@@ -611,29 +611,29 @@ TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(Span
 # TopK basic: { } | rate() by(resource.service.name) | topk(5)
 { } | rate() by(resource.service.name) | topk(5)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))
 
 # BottomK basic: { } | rate() by(resource.service.name) | bottomk(5)
 { } | rate() by(resource.service.name) | bottomk(5)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))
 
 # TopK with more complex query: { resource.service.name = "foo" } | rate() by (span.http.url) | topk(10)
 { resource.service.name = "foo" } | rate() by (span.http.url) | topk(10)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Span, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(AttributeField(Resource, Identifier)), FieldOp, FieldExpression(Static(String)))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType, GroupOperation(FieldExpression(AttributeField(Span, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))
 
 # BottomK with histogram: { status = error } | histogram_over_time(duration) by(resource.a) | bottomk(3)
 { status = error } | histogram_over_time(duration) by(resource.a) | bottomk(3)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationHistogram(MetricsExpression(IntrinsicField), GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter(FieldExpression(FieldExpression(IntrinsicField), FieldOp, FieldExpression(Static))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationHistogram(MetricsExpression(IntrinsicField), GroupOperation(FieldExpression(AttributeField(Resource, Identifier)))))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))
 
 # TopK without grouping: { } | rate() | topk(5)
 { } | rate() | topk(5)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(TopK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))
 
 # BottomK without grouping: { } | rate() | bottomk(5)
 { } | rate() | bottomk(5)
 ==>
-TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType(BottomK), Integer)))))
+TraceQL(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipelineExpression(SpansetPipeline(SpansetFilter)), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsOperation(MetricsOperationBasic(MetricsOperationBasicType))))), Pipe, SpansetPipelineExpression(SpansetPipeline(MetricsAggregatorFunctions(MetricsAggregatorFunctionType, Integer)))))


### PR DESCRIPTION
- Add metrics 2nd level grammar rule for topk and bottomk functions
- Support topk(k) and bottomk(k) syntax following MetricsOperation and grouping
- Add unit tests

Partially fixes: https://github.com/grafana/grafana/issues/103991