### PR TITLE
Release v0.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/lezer-traceql",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "Apache-2.0",
       "devDependencies": {
         "@lezer/generator": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/lezer-traceql",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Grafana Tempo TraceQL lezer grammar",
   "main": "index.cjs",
   "type": "module",


### PR DESCRIPTION
Bump version to 0.0.24.

Includes
- support for 2nd level TraceQL functions (`topk`, `bottomk`)