### PR TITLE
ci: restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,7 +17,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
## Summary
- Add `permissions: {}` to the CI workflow to follow least-privilege defaults
- Minor formatting cleanup (quote style, trailing newline)

## Test plan
- CI workflow runs build and tests on push/PR